### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,7 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-wl-extensions-configuration-secrets
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Jira issue link: [feng-722](https://workleap.atlassian.net/browse/feng-722)

This pull request updates the `.github/workflows/publish.yml` file to include a new configuration parameter for deployment.

* Workflow configuration update:
  * Added the `cortexEntityIdOrTag` parameter with the value `service-wl-extensions-configuration-secrets` to the `jobs:` section. This change likely associates the deployment with a specific Cortex entity or tag.